### PR TITLE
Use WiFiManager to avoid exposed passwords

### DIFF
--- a/arduino/ws2812_controller/ws2812_controller.ino
+++ b/arduino/ws2812_controller/ws2812_controller.ino
@@ -1,23 +1,34 @@
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
 #include <WebSocketsServer.h>
+// needed for library WiFiManager
+#include <DNSServer.h>
+#include <ESP8266WebServer.h>
+#include <WiFiManager.h>  //https://github.com/tzapu/WiFiManager
 #include <Hash.h>
 #include <WiFiUdp.h>
 #include "ws2812_i2s.h"
 
+
+// ***************************************************************************
+// Callback for WiFiManager library when config mode is entered
+// ***************************************************************************
+// gets called when WiFiManager enters configuration mode
+void configModeCallback(WiFiManager *myWiFiManager) {
+  Serial.println("Entered config mode");
+  Serial.println(WiFi.softAPIP());
+  // if you used auto generated SSID, print it
+  Serial.println(myWiFiManager->getConfigPortalSSID());
+  // entered config mode, make led toggle faster
+}
+
 // Set to the number of LEDs in your LED strip
-#define NUM_LEDS 60
+#define NUM_LEDS 256
 // Maximum number of packets to hold in the buffer. Don't change this.
 #define BUFFER_LEN 1024
 // Toggles FPS output (1 = print FPS over serial, 0 = disable output)
 #define SERIAL_OUTPUT 1
 
-// Connection settings
-const char* ssid     = "YOUR-SSID";
-const char* password = "YOUR-PASSWORD"; 
-IPAddress ip(192, 168, 0, 150);
-IPAddress gateway(192, 168, 0, 1);
-IPAddress subnet(255, 255, 255, 0);
 
 // Do not change unless you know what you are doing
 char magicPacket[] = "ESP8266 DISCOVERY";
@@ -31,28 +42,58 @@ WiFiUDP port;
 
 
 void setup() {
+    // Generate a pseduo-unique hostname
+    char hostname[strlen("NODEMCU")+6];
+    uint16_t chipid = ESP.getChipId() & 0xFFFF;
+    sprintf(hostname, "%s-%04x", "NODEMCU", chipid);
+
+
     Serial.begin(115200);
-    WiFi.config(ip, gateway, subnet);
-    WiFi.begin(ssid, password);
-    Serial.println("");
-    // Connect to wifi and print the IP address over serial
-    while (WiFi.status() != WL_CONNECTED) {
-        delay(500);
-        Serial.print(".");
+    Serial.printf("system_get_cpu_freq: %d\n", system_get_cpu_freq());
+
+    // ***************************************************************************
+    // Setup: WiFiManager
+    // ***************************************************************************
+    // Local intialization. Once its business is done, there is no need to keep it
+    // around
+    WiFiManager wifiManager;
+    // reset settings - for testing
+    wifiManager.resetSettings();
+
+    // set callback that gets called when connecting to previous WiFi fails, and
+    // enters Access Point mode
+    wifiManager.setAPCallback(configModeCallback);
+
+    // fetches ssid and pass and tries to connect
+    // if it does not connect it starts an access point with the specified name
+    // here  "AutoConnectAP"
+    // and goes into a blocking loop awaiting configuration
+    if (!wifiManager.autoConnect(hostname)) {
+        Serial.println("failed to connect and hit timeout");
+        // reset and try again, or maybe put it to deep sleep
+        ESP.reset();
+        delay(1000);
     }
-    Serial.println("");
-    Serial.print("Connected to ");
-    Serial.println(ssid);
+    // if you get here you have connected to the WiFi
+    Serial.println("connected...yayy :)");
     Serial.print("IP address: ");
     Serial.println(WiFi.localIP());
+    // keep LED on
+    digitalWrite(BUILTIN_LED, LOW);
+
     port.begin(localPort);
     ledstrip.init(NUM_LEDS);
 }
 
 uint16_t N = 0;
+#if SERIAL_OUTPUT
+    uint32_t fpsCounter = 0;
+    uint32_t secondTimer = 0;
+    uint32_t frames = 0;
+#endif
 
 void loop() {
-    
+
     uint16_t packetSize = port.parsePacket();
 
     // Prevent a crash and buffer overflow
@@ -62,8 +103,8 @@ void loop() {
     }
 
     if (packetSize) {
-        uint16_t len = port.read(packetBuffer, BUFFER_LEN);    
-        
+        uint16_t len = port.read(packetBuffer, BUFFER_LEN);
+
         // Check for a magic packet discovery broadcast
         if (!strcmp(packetBuffer, magicPacket)) {
             char reply[50];
@@ -84,8 +125,20 @@ void loop() {
             pixels[N].B = (uint8_t)packetBuffer[i+2];
             N += 1;
         }
+        ledstrip.show(pixels);
+        #if SERIAL_OUTPUT
+        frames++;
+        #endif
     }
-    ledstrip.show(pixels);
+    #if SERIAL_OUTPUT
+    fpsCounter++;
+    if (millis() - secondTimer >= 1000U) {
+        secondTimer = millis();
+        Serial.printf("FPS: %d\tREAL: %d\n", fpsCounter, frames);
+        fpsCounter = 0;
+        frames = 0;
+    }
+    #endif
 }
 
 // Sends a UDP reply packet to the sender


### PR DESCRIPTION
This pull is to add WiFiManager, which allows the NodeMCU to be used in any unfamiliar wireless environment by connecting to it (currently set to be name NODEMCU-xxxx) and going to `192.168.4.1` in a browser. Select any wireless network available and enter the password. The ESP8266 unit will remember it and automatically connect until its flash is erased. 