### PR TITLE
no longer crashes on raspberry pi

### DIFF
--- a/python/microphone.py
+++ b/python/microphone.py
@@ -16,7 +16,7 @@ def start_stream(callback):
     prev_ovf_time = time.time()
     while True:
         try:
-            y = np.fromstring(stream.read(frames_per_buffer), dtype=np.int16)
+            y = np.fromstring(stream.read(frames_per_buffer, exception_on_overflow=False), dtype=np.int16)
             y = y.astype(np.float32)
             callback(y)
         except IOError:


### PR DESCRIPTION
Tested at 60fps cap with 300 pixels. Averages around 40-50 fps on the Raspberry Pi 3.

This fix removes overflow tracking, but prevents the program from crashing after a single overflow.