### PR TITLE
Fixed audio stream overflow bug on raspberry pi

### DIFF
--- a/python/microphone.py
+++ b/python/microphone.py
@@ -16,7 +16,7 @@ def start_stream(callback):
     prev_ovf_time = time.time()
     while True:
         try:
-            y = np.fromstring(stream.read(frames_per_buffer), dtype=np.int16)
+            y = np.fromstring(stream.read(frames_per_buffer, exception_on_overflow=False), dtype=np.int16)
             y = y.astype(np.float32)
             callback(y)
         except IOError:

--- a/python/microphone.py
+++ b/python/microphone.py
@@ -18,6 +18,7 @@ def start_stream(callback):
         try:
             y = np.fromstring(stream.read(frames_per_buffer, exception_on_overflow=False), dtype=np.int16)
             y = y.astype(np.float32)
+            stream.read(get_read_available(), exception_on_overflow=False)
             callback(y)
         except IOError:
             overflows += 1

--- a/python/microphone.py
+++ b/python/microphone.py
@@ -18,7 +18,7 @@ def start_stream(callback):
         try:
             y = np.fromstring(stream.read(frames_per_buffer, exception_on_overflow=False), dtype=np.int16)
             y = y.astype(np.float32)
-            stream.read(get_read_available(), exception_on_overflow=False)
+            stream.read(stream.get_read_available(), exception_on_overflow=False)
             callback(y)
         except IOError:
             overflows += 1


### PR DESCRIPTION
No longer overflows the audio buffer, and if it does it no longer generates errors that cause the stream to crash.