### PR TITLE
Create setup.py, add entry point for esp8266

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ Temporary Items
 .apdisk
 *.pyc
 *.pdf
+
+# Python setup stuff
+*.egg-info
+build
+dist
+.venv

--- a/python/esp8266_main.py
+++ b/python/esp8266_main.py
@@ -1,0 +1,31 @@
+import argparse
+import config
+import microphone
+import led
+import visualization
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('-i', '--ip', help='IP address', required=True)
+  parser.add_argument('-p', '--port', help='UDP port', default=7777, type=int)
+  parser.add_argument('-n', '--num-leds', help='Number of LEDs', required=True, type=int)
+  parser.add_argument('-f', '--fps', dest='fps', default=60, type=int)
+  parser.add_argument('-d', '--display_fps', dest='display_fps', action='store_true')
+  parser.set_defaults(display_fps=False)
+  args = parser.parse_args()
+  
+  config.UDP_IP = args.ip
+  config.UDP_PORT = args.port
+  config.N_PIXELS = args.num_leds
+  config.USE_GUI = False
+  config.DISPLAY_FPS = args.display_fps
+  config.FPS = args.fps
+
+  # Initialize LEDs
+  led.update()
+  # Start listening to live audio stream
+  microphone.start_stream(visualization.microphone_update)
+
+if __name__ == '__main__':
+  main()
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+with open("README.md", 'r') as f:
+    long_description = f.read()
+
+setup(
+    name='audio_reactive_led_strip',
+    version='0.0.1',
+    description='Music LED strip',
+    author='Some guy',
+    long_description=long_description,
+    author_email='foomail@foo.com',
+    #packages=find_packages(),  # same as name
+    packages=['audio_reactive_led_strip'],
+    package_dir={'audio_reactive_led_strip': 'python'},
+    package_data={'audio_reactive_led_strip': ['*.npy']},
+    # external packages as dependencies
+    install_requires=['numpy', 'scipy', 'pyaudio', 'argparse'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
+    entry_points = {
+        'console_scripts': ['esp8266_music=audio_reactive_led_strip.esp8266_main:main'],
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ with open("README.md", 'r') as f:
 setup(
     name='audio_reactive_led_strip',
     version='0.0.1',
-    description='Music LED strip',
-    author='Some guy',
+    description='Audio Reactive LED strip',
+    author='scottlawsonbc',
     long_description=long_description,
-    author_email='foomail@foo.com',
+    author_email='',
     #packages=find_packages(),  # same as name
     packages=['audio_reactive_led_strip'],
     package_dir={'audio_reactive_led_strip': 'python'},
@@ -18,6 +18,6 @@ setup(
     install_requires=['numpy', 'scipy', 'pyaudio', 'argparse'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4',
     entry_points = {
-        'console_scripts': ['esp8266_music=audio_reactive_led_strip.esp8266_main:main'],
+        'console_scripts': ['audio_reactive_led_strip=audio_reactive_led_strip.esp8266_main:main'],
     }
 )


### PR DESCRIPTION
This allows installation as a command line tool.

When installed with `python setup.py`, it installs an executable that can start the visualization as follows:
```
esp8266_music --ip 192.168.50.131 -n 60 -d
```