### PR TITLE
TypeError: in method ‘ws2811_led_set’, argument 3 of type ‘uint32_t’ …

### DIFF
--- a/python/led.py
+++ b/python/led.py
@@ -104,7 +104,8 @@ def _update_pi():
         # Ignore pixels if they haven't changed (saves bandwidth)
         if np.array_equal(p[:, i], _prev_pixels[:, i]):
             continue
-        strip._led_data[i] = rgb[i]
+        #strip._led_data[i] = rgb[i]
+        strip._led_data[i] = int(rgb[i])
     _prev_pixels = np.copy(p)
     strip.show()
 


### PR DESCRIPTION
…FIXED