### PR TITLE
docs: fix simple typo, continously -> continuously

### DIFF
--- a/python/led.py
+++ b/python/led.py
@@ -150,7 +150,7 @@ def update():
 
 # Execute this file to run a LED strand test
 # If everything is working, you should see a red, green, and blue pixel scroll
-# across the LED strip continously
+# across the LED strip continuously
 if __name__ == '__main__':
     import time
     # Turn all pixels off


### PR DESCRIPTION
There is a small typo in python/led.py.

Should read `continuously` rather than `continously`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md