### PR TITLE
Fixed Error with PyQt & Fixed Deprecation with SciPy

### DIFF
--- a/python/led.py
+++ b/python/led.py
@@ -79,7 +79,8 @@ def _update_esp8266():
                 m.append(p[1][i])  # Pixel green value
                 m.append(p[2][i])  # Pixel blue value
         m = m if _is_python_2 else bytes(m)
-        _sock.sendto(m, (config.UDP_IP, config.UDP_PORT))
+        if len(m) > 0:
+            _sock.sendto(m, (config.UDP_IP, config.UDP_PORT))
     _prev_pixels = np.copy(p)
 
 


### PR DESCRIPTION
Fixed these two little things:

Traceback (most recent call last):
  File "/home/anonym/GitHub/audio-reactive-led-strip/python/visualization.py", line 260, in <module>
    app = QtGui.QApplication([])
AttributeError: module 'pyqtgraph.Qt.QtGui' has no attribute 'QApplication'

&

Please use `gaussian_filter1d` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.